### PR TITLE
APDS970x power consumption

### DIFF
--- a/sensors/apds970x.c
+++ b/sensors/apds970x.c
@@ -66,7 +66,7 @@ static struct sensor_desc apds970x = {
 		.type = SENSOR_TYPE_PROXIMITY,
 		.maxRange = 1.0,
 		.resolution = 1.0,
-		.power = 20
+		.power = 2
 	},
 	.api = {
 		.init = apds9700_init,


### PR DESCRIPTION
APDS-9700/APDS-9702 only use 2mA and not 20mA.
APDS-9700 Datasheet: http://www.avagotech.com/docs/AV02-0893EN
APDS-9702 Datasheet: http://www.avagotech.com/docs/AV02-2238EN

Signed-off-by: Henning Nielsen Lund hnl_dk@amigaos.dk
