### PR TITLE
Fix sensors_worker to work with delays greater than or equal to 1 second...

### DIFF
--- a/sensors_worker.c
+++ b/sensors_worker.c
@@ -29,9 +29,8 @@ static void sensor_nano_sleep(int64_t utime)
 	if (utime <= 0)
 		return;
 
-	memset(&t, 0, sizeof(t));
-	t.tv_nsec = (long)(utime);
-
+	t.tv_sec = (time_t)(utime / 1e9);
+	t.tv_nsec = (long)(utime % 1000000000L);
 	nanosleep(&t, NULL);
 }
 


### PR DESCRIPTION
sensors_worker behaved erratically when a delay greater or equal to one second was specified. Only the lower 32 bits of the nanosecond value were used, which would sometimes evaluate to a negative number.
The change handles the second- and subsecond parts correctly in sensors_nano_sleep. Alternatively the sensors_worker could store a struct timespec and do the conversion only once in sensors_worker_set_delay.
