### PR TITLE
bma150 & bma250: adjust mindelay to 5ms

### DIFF
--- a/sensors/bma150_input.c
+++ b/sensors/bma150_input.c
@@ -77,7 +77,7 @@ static struct sensor_desc bma150_input = {
 		maxRange: 9.81,
 		resolution: 20,
 		power: 0.13,
-		minDelay: 10000
+		minDelay: 5000
 	},
 	.api = {
 		init: bma150_input_init,

--- a/sensors/bma250_input.c
+++ b/sensors/bma250_input.c
@@ -78,7 +78,7 @@ static struct sensor_desc bma250_input = {
 		maxRange: 156.96, /* max +/-16G */
 		resolution: 20,
 		power: 0.003,/* sleep 50ms */
-		minDelay: 10000000
+		minDelay: 5000
 	},
 	.api = {
 		init: bma250_input_init,


### PR DESCRIPTION
In AOSP there is a huge lag in accelerometer on devices using bma250 & bma150, mostly noticed in screen rotation and while playing games that require accelerometer (they are unplayable because of the huge lag).

This affects the whole Xperia 2011 line.

With the current mindelay, accelerometer does not continuously report x/y/z movements and when it does, it is very laggy. After applying this change the accelerometer does a continuous & smooth report of x/y/z movements. Tested and working on ST15i/smultron.

You can install Accelerometer Monitor from Play store and check without & with this change, there's big difference.

Signed-off-by: Michael Bestas mikeioannina@gmail.com
