### PR TITLE
Bma250 error print cleanup

### DIFF
--- a/sensors/bma250_input.c
+++ b/sensors/bma250_input.c
@@ -214,22 +214,15 @@ static int bma250_input_set_delay(struct sensor_api_t *s, int64_t ns)
 	/* rate */
 	ret = d->sysfs.write_int(&d->sysfs, "bma250_rate", ms);
 	if (ret < 0) {
-		ALOGE("%s: sysfs.write_int failed!\n", __func__);
+		ALOGE("updating bma250_rate failed: %s\n", strerror(-ret));
 		return ret;
 	}
 
-	/* range */
-	ret = d->sysfs.write_int(&d->sysfs, "bma250_range", 2);
-	if (ret < 0) {
-		ALOGE("%s: sysfs.write_int failed!\n", __func__);
-		return ret;
-	}
+	/* range (optional) */
+	d->sysfs.write_int(&d->sysfs, "bma250_range", 2);
 
-	/* resolution */
-	ret = d->sysfs.write_int(&d->sysfs, "bma250_resolution",
-		(ms > 50) ? 0 : 1);
-	if (ret < 0)
-		ALOGE("%s: sysfs.write_int failed!\n", __func__);
+	/* resolution (optional) */
+	d->sysfs.write_int(&d->sysfs, "bma250_resolution", (ms > 50) ? 0 : 1);
 
 	return ret;
 }

--- a/sensors/bma250na_input.c
+++ b/sensors/bma250na_input.c
@@ -192,13 +192,18 @@ static int bma250_input_set_delay(struct sensor_api_t *s, int64_t ns)
 	struct sensor_desc *d = container_of(s, struct sensor_desc, api);
 	int fd = d->select_worker.get_fd(&d->select_worker);
 	int64_t usec = ns / 1000;
+	int ret;
 
 	if (usec < d->sensor.minDelay)
 		usec = d->sensor.minDelay;
 
 	d->delay = usec * 1000;
 	d->select_worker.set_delay(&d->select_worker, d->delay);
-	return d->sysfs.write_int(&d->sysfs, "bma250_rate", usec / 1000);
+	ret = d->sysfs.write_int(&d->sysfs, "bma250_rate", usec / 1000);
+	if (ret < 0)
+		ALOGE("updating bma250_rate failed: %s\n", strerror(-ret));
+
+	return ret;
 }
 
 static void bma250_input_close(struct sensor_api_t *s)


### PR DESCRIPTION
Had some issues with permissions in sysfs, but the error prints didn't tell me I had a problem with DASH nor what file it actually had a problem with; this improves the error logging to the point where it's actually helpful.
