### PR TITLE
akm8963: Make compilation of dummy library optional

### DIFF
--- a/libs/akm8963/Android.mk
+++ b/libs/akm8963/Android.mk
@@ -2,7 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+ifneq ($(SOMC_CFG_SENSORS_AKM8963_DUMMY),)
+
 LOCAL_MODULE := libsensors_akm8963
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES += ak8963_dummy.c
 include $(BUILD_SHARED_LIBRARY)
+
+endif


### PR DESCRIPTION
For systems where the akm8963 library is present we don't want to
compile the dash dummy library.

Change-Id: If6b87696229edc6ae297f20e8003cc6207f18a55
Signed-off-by: Bjorn Andersson bjorn.andersson@sonymobile.com
