### PR TITLE
DASH: sensors: Use monotonic time since boot for event timestamps

### DIFF
--- a/sensors/sensor_util.c
+++ b/sensors/sensor_util.c
@@ -39,7 +39,7 @@ static int64_t timespec_to_ns(const struct timespec *ts)
 int64_t get_current_nano_time()
 {
 	struct timespec t;
-	clock_gettime(CLOCK_MONOTONIC, &t);
+	clock_gettime(CLOCK_BOOTTIME, &t);
 	return timespec_to_ns(&t);
 }
 


### PR DESCRIPTION
 * Recent Android versions are expecting a monotonic timestamp that includes the
    time since boot, not the time elapsed since boot while the device was awake.
 * Adapted to hardware_sony_dash from I299af0d9a35219a856fdbc225d11dbb3ff95db77
 * Fixes display autorotation in Android 6.0

Change-Id: I85980c2ebfeaf44629b75d6b80d9aa01d9ce453e
Signed-off-by: AdrianDC <radian.dc@gmail.com>