### PR TITLE
DASH: Remove the sensors compilation timestamps

### DIFF
--- a/sensors/sensor_xyz.c
+++ b/sensors/sensor_xyz.c
@@ -269,9 +269,8 @@ void *sensor_xyz_read(void *arg)
 
 	n = read(fd, events, sizeof(events));
 	if (n < 0) {
-		ALOGE("%s: read error '%s' from fd %d sensor '%s' built %s @ %s",
-			__func__, strerror(errno), fd, p->sensor.name,
-			__DATE__, __TIME__);
+		ALOGE("%s: read error '%s' from fd %d sensor '%s'",
+			__func__, strerror(errno), fd, p->sensor.name);
 		return NULL;
 	} else if (n == 0) {
 		ALOGE("%s: read error end of file from fd %d, sensor '%s'",


### PR DESCRIPTION
- Storing the library compilation time for a specific log
  is not required and breaks the build
- Fixes "expansion of date or time macro is not reproducible"

Change-Id: Ifcb6d5a27c7a51a2da4bb618812e358f2e2dc9d6
